### PR TITLE
Fix and expand grch build detection

### DIFF
--- a/src/snps/io/reader.py
+++ b/src/snps/io/reader.py
@@ -253,8 +253,10 @@ class Reader:
             return 37
         elif "hg38" in comments.lower():
             return 38
-        elif "GRCh38" in comments.lower():
+        elif "grch38" in comments.lower():
             return 38
+        elif "grch37" in comments.lower():
+            return 37
         elif "build 38" in comments.lower():
             return 38
         elif "b38" in comments.lower():

--- a/tests/io/test_writer.py
+++ b/tests/io/test_writer.py
@@ -44,7 +44,11 @@ class TestWriter(BaseSNPsTestCase):
     def test_save_snps(self):
         snps = SNPs("tests/input/generic.csv")
         self.assertEqual(os.path.relpath(snps.save_snps()), "output/generic_GRCh37.csv")
-        self.run_parsing_tests("output/generic_GRCh37.csv", "generic")
+        self.run_parsing_tests(
+            "output/generic_GRCh37.csv",
+            "generic",
+           build_detected=True  # build will be detected from comments because save_snps() writes the build into comments
+        )
 
     def test_save_snps_tsv(self):
         snps = SNPs("tests/input/generic.csv")
@@ -52,7 +56,11 @@ class TestWriter(BaseSNPsTestCase):
             os.path.relpath(snps.save_snps("generic.tsv", sep="\t")),
             "output/generic.tsv",
         )
-        self.run_parsing_tests("output/generic.tsv", "generic")
+        self.run_parsing_tests(
+            "output/generic.tsv", 
+            "generic",
+           build_detected=True  # build will be detected from comments because save_snps() writes the build into comments
+        )
 
     def test_save_snps_vcf(self):
         s = SNPs("tests/input/testvcf.vcf")
@@ -104,9 +112,16 @@ class TestWriter(BaseSNPsTestCase):
         # save phased data to CSV
         self.assertEqual(os.path.relpath(s.save_snps()), "output/vcf_GRCh37.csv")
         # read saved CSV
-        self.run_parsing_tests_vcf("output/vcf_GRCh37.csv", phased=True)
+        self.run_parsing_tests_vcf("output/vcf_GRCh37.csv", 
+            phased=True,
+           build_detected=True  # build will be detected from comments because save_snps() writes the build into comments
+        )
 
     def test_save_snps_specify_file(self):
         s = SNPs("tests/input/generic.csv")
         self.assertEqual(os.path.relpath(s.save_snps("snps.csv")), "output/snps.csv")
-        self.run_parsing_tests("output/snps.csv", "generic")
+        self.run_parsing_tests(
+            "output/snps.csv", 
+            "generic",
+           build_detected=True  # build will be detected from comments because save_snps() writes the build into comments
+        )

--- a/tests/io/test_writer.py
+++ b/tests/io/test_writer.py
@@ -47,7 +47,7 @@ class TestWriter(BaseSNPsTestCase):
         self.run_parsing_tests(
             "output/generic_GRCh37.csv",
             "generic",
-           build_detected=True  # build will be detected from comments because save_snps() writes the build into comments
+            build_detected=True,  # build will be detected from comments because save_snps() writes the build into comments
         )
 
     def test_save_snps_tsv(self):
@@ -57,9 +57,9 @@ class TestWriter(BaseSNPsTestCase):
             "output/generic.tsv",
         )
         self.run_parsing_tests(
-            "output/generic.tsv", 
+            "output/generic.tsv",
             "generic",
-           build_detected=True  # build will be detected from comments because save_snps() writes the build into comments
+            build_detected=True,  # build will be detected from comments because save_snps() writes the build into comments
         )
 
     def test_save_snps_vcf(self):
@@ -112,16 +112,17 @@ class TestWriter(BaseSNPsTestCase):
         # save phased data to CSV
         self.assertEqual(os.path.relpath(s.save_snps()), "output/vcf_GRCh37.csv")
         # read saved CSV
-        self.run_parsing_tests_vcf("output/vcf_GRCh37.csv", 
+        self.run_parsing_tests_vcf(
+            "output/vcf_GRCh37.csv",
             phased=True,
-           build_detected=True  # build will be detected from comments because save_snps() writes the build into comments
+            build_detected=True,  # build will be detected from comments because save_snps() writes the build into comments
         )
 
     def test_save_snps_specify_file(self):
         s = SNPs("tests/input/generic.csv")
         self.assertEqual(os.path.relpath(s.save_snps("snps.csv")), "output/snps.csv")
         self.run_parsing_tests(
-            "output/snps.csv", 
+            "output/snps.csv",
             "generic",
-           build_detected=True  # build will be detected from comments because save_snps() writes the build into comments
+            build_detected=True,  # build will be detected from comments because save_snps() writes the build into comments
         )


### PR DESCRIPTION
Comparing an upper case containing string to a lower case string will never match, thus can't detect GRCh37 containing comments. Also missing an equivalent for GRCh38 build files.