### PR TITLE
add chromosome 1 size to build detection

### DIFF
--- a/src/snps/io/reader.py
+++ b/src/snps/io/reader.py
@@ -261,7 +261,12 @@ class Reader:
             return 38
         elif "b38" in comments.lower():
             return 38
-        return 0
+        elif "249250621" in comments.lower():
+            return 37  # length of chromosome 1
+        elif "248956422" in comments.lower():
+            return 38  # length of chromosome 1
+        else:
+            return 0
 
     def _handle_bytes_data(self, file, include_data=False):
         compression = "infer"


### PR DESCRIPTION
To facilitate build detection in some older imputed vcf files, this adds the chromosome lengths as strings to detect build on, if nothing else has worked so far.