### PR TITLE
Fix strand to read of Sano files 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,7 @@ tests/output/
 tests/resources/*
 !tests/resources/gsa_chrpos_map.txt
 !tests/resources/gsa_rsid_map.txt
+!tests/resources/dbsnp_151_37_reverse.txt
 tests/input/23andme.txt.zip
 tests/input/discrepant_snps[12].csv
 tests/input/ftdna.csv.gz

--- a/src/snps/io/reader.py
+++ b/src/snps/io/reader.py
@@ -813,13 +813,14 @@ class Reader:
                 if row["Chr"]:
                     row["chrom"] = row["Chr"]
                 elif snp_name in gsa_resources["chrpos_map"]:
-                    row["chrom"] = gsa_resources["chrpos_map"].get(snp_name).split(":")[0]
+                    row["chrom"] = (
+                        gsa_resources["chrpos_map"].get(snp_name).split(":")[0]
+                    )
 
                 if row["Position"]:
                     row["pos"] = row["Position"]
                 elif snp_name in gsa_resources["chrpos_map"]:
                     row["pos"] = gsa_resources["chrpos_map"].get(snp_name).split(":")[1]
-
 
                 if pd.isna(row[f"Allele1 - {strand}"]) or pd.isna(
                     row[f"Allele2 - {strand}"]

--- a/src/snps/io/reader.py
+++ b/src/snps/io/reader.py
@@ -769,6 +769,11 @@ class Reader:
     def _read_gsa_helper(self, file, source, strand, dtypes, na_values="--"):
         def parser():
             gsa_resources = self._resources.get_gsa_resources()
+            dbsnp_reverse = (
+                self._resources.get_dbsnp_151_37_reverse()
+                if strand == "Forward"
+                else {}
+            )
 
             if isinstance(file, str):
                 try:
@@ -793,27 +798,65 @@ class Reader:
             data_io = io.StringIO(data)
             df = pd.read_csv(data_io, sep="\t", dtype=dtypes, na_values=na_values)
 
-            def map_rsids(x):
-                return gsa_resources["rsid_map"].get(x)
+            rev_comp = {}
+            rev_comp["A"] = "T"
+            rev_comp["T"] = "A"
+            rev_comp["G"] = "C"
+            rev_comp["C"] = "G"
 
-            def map_chr(x):
-                chrpos = gsa_resources["chrpos_map"].get(x)
-                return chrpos.split(":")[0] if chrpos else None
+            def map_row(row):
+                snp_name = row["SNP Name"]
 
-            def map_pos(x):
-                chrpos = gsa_resources["chrpos_map"].get(x)
-                return chrpos.split(":")[1] if chrpos else None
+                row["rsid"] = gsa_resources["rsid_map"].get(snp_name, snp_name)
 
-            df["rsid"] = df["SNP Name"].apply(map_rsids)
-            df["chrom"] = df["SNP Name"].apply(map_chr)
-            df["pos"] = df["SNP Name"].apply(map_pos)
-            df["genotype"] = (
-                df["Allele1 - {}".format(strand)] + df["Allele2 - {}".format(strand)]
-            )
+                # prefer the chromosone and position from the map (because ?)
+                row["chrom"] = (
+                    gsa_resources["chrpos_map"].get(snp_name).split(":")[0]
+                    if snp_name in gsa_resources["chrpos_map"]
+                    else row["Chr"]
+                )
+                row["pos"] = (
+                    gsa_resources["chrpos_map"].get(snp_name).split(":")[1]
+                    if snp_name in gsa_resources["chrpos_map"]
+                    else row["Position"]
+                )
+
+                if pd.isna(row[f"Allele1 - {strand}"]) or pd.isna(
+                    row[f"Allele2 - {strand}"]
+                ):
+                    # known alleles mean unknnown genotype
+                    row["genotype"] = np.nan  # pd.NA for pandas > 1.0.0
+                elif strand == "Forward" and snp_name in dbsnp_reverse:
+                    # if strand is forward, need to take reverse complement of *some* rsids
+                    # this is because it is Illumina forward, which is dbSNP strand, which
+                    # is reverse reference for some RSIDs before dbSNP 151.
+                    row["genotype"] = rev_comp.get(
+                        row[f"Allele1 - {strand}"], "-"
+                    ) + rev_comp.get(row[f"Allele2 - {strand}"], "-")
+                else:
+                    # build the genotype by joining the alleles
+                    row["genotype"] = (
+                        row[f"Allele1 - {strand}"] + row[f"Allele2 - {strand}"]
+                    )
+
+                return row
+
+            # ensure appropriate data types
+            df["chrom"] = ""
+            df["pos"] = 0
+            df["genotype"] = ""
+
+            # convert each row into desired structure]
+            df = df.apply(map_row, axis=1)
+            df = df.astype({"chrom": object, "pos": np.int64, "genotype": object})
+
+            # trim to just desired columns
+            df = df[["rsid", "chrom", "pos", "genotype"]]
+
+            # discard rows without values
             df.dropna(subset=["rsid", "chrom", "pos"], inplace=True)
 
-            df = df.astype({"chrom": object, "pos": np.int64})
-            df = df[["rsid", "chrom", "pos", "genotype"]]
+            # reindex for the new identifiers
             df.set_index(["rsid"], inplace=True)
 
             return (df,)
@@ -872,7 +915,13 @@ class Reader:
         dict
             result of `read_helper`
         """
-        return self._read_gsa_helper(file, "Codigo46", "Plus", {})
+        dtype = {
+            "Chr": object,
+            "Position": np.int64,
+            "Allele1 - Plus": object,
+            "Allele2 - Plus": object,
+        }
+        return self._read_gsa_helper(file, "Codigo46", "Plus", dtype, na_values="-",)
 
     def read_sano(self, file):
         """ Read and parse Sano Genetics files.
@@ -889,7 +938,12 @@ class Reader:
         dict
             result of `read_helper`
         """
-        dtype = {"Chr": object, "Position": np.int64}
+        dtype = {
+            "Chr": object,
+            "Position": np.int64,
+            "Allele1 - Forward": object,
+            "Allele2 - Forward": object,
+        }
         return self._read_gsa_helper(file, "Sano", "Forward", dtype, na_values="-",)
 
     def read_dnaland(self, file, compression):

--- a/src/snps/io/reader.py
+++ b/src/snps/io/reader.py
@@ -810,17 +810,16 @@ class Reader:
 
                 row["rsid"] = gsa_resources["rsid_map"].get(snp_name, snp_name)
 
-                # prefer the chromosone and position from the map (because ?)
-                row["chrom"] = (
-                    gsa_resources["chrpos_map"].get(snp_name).split(":")[0]
-                    if snp_name in gsa_resources["chrpos_map"]
-                    else row["Chr"]
-                )
-                row["pos"] = (
-                    gsa_resources["chrpos_map"].get(snp_name).split(":")[1]
-                    if snp_name in gsa_resources["chrpos_map"]
-                    else row["Position"]
-                )
+                if row["Chr"]:
+                    row["chrom"] = row["Chr"]
+                elif snp_name in gsa_resources["chrpos_map"]:
+                    row["chrom"] = gsa_resources["chrpos_map"].get(snp_name).split(":")[0]
+
+                if row["Position"]:
+                    row["pos"] = row["Position"]
+                elif snp_name in gsa_resources["chrpos_map"]:
+                    row["pos"] = gsa_resources["chrpos_map"].get(snp_name).split(":")[1]
+
 
                 if pd.isna(row[f"Allele1 - {strand}"]) or pd.isna(
                     row[f"Allele2 - {strand}"]

--- a/src/snps/resources.py
+++ b/src/snps/resources.py
@@ -264,8 +264,8 @@ class Resources(metaclass=Singleton):
         return self._gsa_resources
 
     def get_dbsnp_151_37_reverse(self):
-        """Get dict of RSIDs and allelel population frequencies (when known) that are potentially 
-        on the reference reverse strand in dbSNP 151 and lower
+        """Get dict of RSIDs and allele population frequencies (when known) that are potentially 
+        on the reference reverse(-) strand in dbSNP 151 and lower
 
         Returns
         -------

--- a/src/snps/resources.py
+++ b/src/snps/resources.py
@@ -83,6 +83,7 @@ class Resources(metaclass=Singleton):
         self._ensembl_rest_client = EnsemblRestClient()
         self._reference_sequences = {}
         self._gsa_resources = {}
+        self._dbsnp_151_37_reverse = {}
         self._opensnp_datadump_filenames = []
 
     def get_reference_sequences(
@@ -261,6 +262,42 @@ class Resources(metaclass=Singleton):
                 self._get_path_gsa_rsid_map(), self._get_path_gsa_chrpos_map()
             )
         return self._gsa_resources
+
+    def get_dbsnp_151_37_reverse(self):
+        """Get dict of RSIDs and allelel population frequencies (when known) that are potentially 
+        on the reference reverse strand in dbSNP 151 and lower
+
+        Returns
+        -------
+        dict
+        """
+        if not self._dbsnp_151_37_reverse:
+            dbsnp_rev_path = self._get_path_dbsnp_151_37_reverse()
+            dbsnp_reverse = {}
+            with gzip.open(dbsnp_rev_path, "rb") as f:
+                for line in f:
+                    line = line.decode("utf-8").strip()
+                    if line.startswith("#"):
+                        continue
+                    line = line.split(" ")
+                    frqs = {}
+                    if len(line) == 1:
+                        rsid = line[0]
+                    elif len(line) == 5:
+                        rsid = line[0]
+                        try:
+                            for frq, base in zip(line[1:5], ("A", "T", "C", "G")):
+                                frqs[base] = frq
+                        except ValueError as e:
+                            # unable to read the line
+                            frqs = {}
+                    else:
+                        # unexpected length of line, skip it
+                        continue
+
+                    dbsnp_reverse[rsid] = frqs
+            self._dbsnp_151_37_reverse = dbsnp_reverse
+        return self._dbsnp_151_37_reverse
 
     def get_opensnp_datadump_filenames(self):
         """ Get filenames internal to the `openSNP <https://opensnp.org>`_ datadump zip.
@@ -602,6 +639,12 @@ class Resources(metaclass=Singleton):
         return self._download_file(
             "https://sano-public.s3.eu-west-2.amazonaws.com/gsa_chrpos_map.txt.gz",
             "gsa_chrpos_map.txt.gz",
+        )
+
+    def _get_path_dbsnp_151_37_reverse(self):
+        return self._download_file(
+            "https://sano-public.s3.eu-west-2.amazonaws.com/dbsnp151.b37.snps_reverse.txt.gz",
+            "dbsnp_151_37_reverse.txt.gz",
         )
 
     def _get_path_opensnp_datadump(self):

--- a/tests/input/codigo46.txt
+++ b/tests/input/codigo46.txt
@@ -1,13 +1,12 @@
 [Header]
 Content		CODIGO46.bpm
 [Data]
-SNP Name	Sample ID	Allele1 - Plus	Allele2 - Plus
-1:101	123	A	A
-1:102	123	C	C
-1:103	123	G	G
-1:104	123	T	T
-1:105	123	--	--
-1:106	123	G	C
-1:107	123	T	C
-1:108	123	A	T
-1:109	123	A	C
+Sample Name	SNP Name	Chr	Position	Allele1 - Plus	Allele2 - Plus
+123	1:101	1	101	A	A
+123	1:102	1	102	C	C
+123	1:103	1	103	G	G
+123	1:104	1	104	T	T
+123	1:105	1	105	-	-
+123	rs6	1	106	G	C
+123	rs7	1	107	T	C
+123	rs8	1	108	A	T

--- a/tests/input/sano.txt
+++ b/tests/input/sano.txt
@@ -1,13 +1,12 @@
 [Header]
 Content		SANO
 [Data]
-SNP Name	Sample ID	Allele1 - Forward	Allele2 - Forward
-1:101	123	A	A
-1:102	123	C	C
-1:103	123	G	G
-1:104	123	T	T
-1:105	123	-	-
-1:106	123	G	C
-1:107	123	T	C
-1:108	123	A	T
-1:109	123	A	C
+Sample Name	SNP Name	Chr	Position	Allele1 - Forward	Allele2 - Forward
+123	1:101	1	101	A	A
+123	1:102	1	102	C	C
+123	1:103	1	103	G	G
+123	1:104	1	104	T	T
+123	1:105	1	105	-	-
+123	rs6	1	106	G	C
+123	rs7	1	107	A	G
+123	rs8	1	108	T	A

--- a/tests/io/test_reader.py
+++ b/tests/io/test_reader.py
@@ -63,6 +63,10 @@ class TestReader(BaseSNPsTestCase):
             "tests/resources/gsa_chrpos_map.txt",
             os.path.join(resources_dir, "gsa_chrpos_map.txt.gz"),
         )
+        gzip_file(
+            "tests/resources/dbsnp_151_37_reverse.txt",
+            os.path.join(resources_dir, "dbsnp_151_37_reverse.txt.gz"),
+        )
 
     @staticmethod
     def _teardown_gsa_test():

--- a/tests/resources/dbsnp_151_37_reverse.txt
+++ b/tests/resources/dbsnp_151_37_reverse.txt
@@ -1,0 +1,3 @@
+# this is a comment
+rs7    
+rs8 0.903 0.0 0.0 0.09704


### PR DESCRIPTION
Fix strand used when reading Sano files to match the reference. see https://emea.support.illumina.com/bulletins/2017/06/how-to-interpret-dna-strand-and-allele-information-for-infinium-.html