### PR TITLE
Use a set for rsids

### DIFF
--- a/src/snps/io/reader.py
+++ b/src/snps/io/reader.py
@@ -79,7 +79,7 @@ class Reader:
         self._file = file
         self._only_detect_source = only_detect_source
         self._resources = resources
-        self._rsids = rsids
+        self._rsids = frozenset(rsids)
 
     def __call__(self):
         """ Read and parse a raw data / genotype file.


### PR DESCRIPTION
For better performance of checking membership for a large number of RSIDs (100s - 1,000s) ensure that the RSIDs are a set data structure with O(1) membership checks rather than O(n).