### PR TITLE
avoid race condition error

### DIFF
--- a/src/snps/resources.py
+++ b/src/snps/resources.py
@@ -702,7 +702,9 @@ class Resources(metaclass=Singleton):
                 # http://stackoverflow.com/a/7244263
                 with urllib.request.urlopen(
                     url, timeout=timeout
-                ) as response, atomic_write(destination, mode="wb", overwrite=True) as f:
+                ) as response, atomic_write(
+                    destination, mode="wb", overwrite=True
+                ) as f:
                     self._print_download_msg(destination)
                     data = response.read()  # a `bytes` object
 

--- a/src/snps/resources.py
+++ b/src/snps/resources.py
@@ -702,7 +702,7 @@ class Resources(metaclass=Singleton):
                 # http://stackoverflow.com/a/7244263
                 with urllib.request.urlopen(
                     url, timeout=timeout
-                ) as response, atomic_write(destination, mode="wb") as f:
+                ) as response, atomic_write(destination, mode="wb", overwrite=True) as f:
                     self._print_download_msg(destination)
                     data = response.read()  # a `bytes` object
 
@@ -724,6 +724,11 @@ class Resources(metaclass=Singleton):
             except socket.timeout:
                 logger.warning(f"Timeout downloading {url}")
                 destination = ""
+            except FileExistsError:
+                # if the file exists, another process has created it while it was
+                # being downloaded
+                # in such a case, the other copy is identical, so ignore this error
+                pass
 
         return destination
 


### PR DESCRIPTION
Prevents the raising of an error when multiple processes download the same file to the same destination at the same time because all the copies will be the same, so which one wins is not important.