### PR TITLE
skip bad ancestry lines

### DIFF
--- a/src/snps/io/reader.py
+++ b/src/snps/io/reader.py
@@ -669,6 +669,7 @@ class Reader:
                 index_col=0,
                 dtype=TWO_ALLELE_DTYPES,
                 compression=compression,
+                error_bad_lines=False,
             )
 
             # create genotype column from allele columns


### PR DESCRIPTION
Sometimes we see ancestry files with a single line with too many separators.

In such cases, ignore the line, but continue parsing the rest of the file.